### PR TITLE
Update angular directive & service schematics

### DIFF
--- a/src/main/frontend/angular.json
+++ b/src/main/frontend/angular.json
@@ -136,6 +136,14 @@
       }
     }
   },
+  "schematics": {
+    "@schematics/angular:directive": {
+      "type": "directive"
+    },
+    "@schematics/angular:service": {
+      "type": "service"
+    }
+  },
   "cli": {
     "analytics": false,
     "packageManager": "pnpm",


### PR DESCRIPTION
This makes sure both directives and services will get the `.directive.ts` or `.service.ts` extension when created by CLI