### PR TITLE
Fix path to cypress artifacts

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,4 +44,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cypress-test-results
-          path: ${{ github.workspace }}/*/target/test-classes/e2e/cypress/test-results
+          path: ${{ github.workspace }}/target/test-classes/e2e/cypress/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/frontend/


### PR DESCRIPTION
Met de wildcard in het pad hiervoor werd er nog een map verwacht tussen de workspace en target map.