### PR TITLE
fixed cypress test container

### DIFF
--- a/src/test/java/org/frankframework/application/RunCypressE2eTest.java
+++ b/src/test/java/org/frankframework/application/RunCypressE2eTest.java
@@ -116,9 +116,13 @@ public class RunCypressE2eTest {
     Stream<DynamicContainer> runCypressTests() throws InterruptedException, IOException, TimeoutException {
         CypressTestResults testResults = container.getTestResults();
 
-        return testResults.getSuites()
-                .stream()
-                .map(this::createContainerFromSuite);
+        if (testResults.getNumberOfFailingTests() > 0) {
+            throw new AssertionError(
+                    "Cypress tests failed! " + testResults.getNumberOfFailingTests() + " test(s) failed.\n\n"
+                            + testResults);
+        }
+
+        return testResults.getSuites().stream().map(this::createContainerFromSuite);
     }
 
     private DynamicContainer createContainerFromSuite(CypressTestSuite suite) {


### PR DESCRIPTION
When the Cypress test fails internally, the Cypress test container doesn't recognize the error. The unit test still passes, and the pipeline succeeds.
With this adjustment it is fixed.

```
[INFO] 
[INFO] Results:
[INFO]
[ERROR] Failures: 
[ERROR]   RunCypressE2eTest.runCypressTests:116 Cypress tests failed! 1 test(s) failed.

Cypress tests run: 67
Cypress tests passing: 66
Cypress tests failing: 1
[INFO]
[ERROR] Tests run: 253, Failures: 1, Errors: 0, Skipped: 0
```

